### PR TITLE
Add documentation for Helm repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,92 @@
+# Created by https://www.toptal.com/developers/gitignore/api/jetbrains+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=jetbrains+all
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+# End of https://www.toptal.com/developers/gitignore/api/jetbrains+all

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # tractus-x-release
+
+## Helm Repository
+
+For information about using the Tractus-X Helm repository, please refer to [this documentation](docs/helm-repsoitory.md).

--- a/docs/helm-repsoitory.md
+++ b/docs/helm-repsoitory.md
@@ -12,8 +12,8 @@ Both branches will be hosted via GitHub Pages within this
 repository ([eclipse-tractus-x/tractus-x-release](https://github.com/eclipse-tractusx/tractus-x-release)) and will be
 accessible under URL
 
-- https://tractus-x-release.github.io/charts/dev for Dev branch
-- https://tractus-x-release.github.io/charts/stable for Stable branch
+- https://eclipse-tractusx.github.io/tractus-x-release/charts/dev for Dev branch
+- https://eclipse-tractusx.github.io/tractus-x-release/charts/stable for Stable branch
 
 ## Availability
 

--- a/docs/helm-repsoitory.md
+++ b/docs/helm-repsoitory.md
@@ -1,0 +1,33 @@
+# Helm Repository for Tractus-X
+
+To have all Tractus-X sub-product Helm Charts in one place, a central Tractus-X Helm Repository is build. The central
+Helm Repository is split into two branches:
+
+- Dev
+- Stable
+
+## Helm Repository URL
+
+Both branches will be hosted via GitHub Pages within this
+repository ([eclipse-tractus-x/tractus-x-release](https://github.com/eclipse-tractus-x/tractus-x-release)) and will be
+accessible under URL
+
+- https://tractus-x-release.github.io/charts/dev for Dev branch
+- https://tractus-x-release.github.io/charts/stable for Stable branch
+
+## Availability
+
+### Dev Branch
+
+Dev branch will contain all released Helm Charts of any Tractus-X sub-product. In the future, only a certain number
+of released Helm charts per Tractus-X sub-product might be kept due to clarity reasons.
+
+The Helm repository for Dev branch will be updated once a day.
+
+### Stable branch
+
+Stable branch will contain all Helm charts versions of Tractus-X sub-products associated with an official Tractus-X
+release. In the future, Helm charts associated with Tractus-X versions which have reached its end of lifetime, will be
+removed from the stable branch.
+
+The Helm repository for stable branch will be updated when a new Tractus-X release or a patch update is released.

--- a/docs/helm-repsoitory.md
+++ b/docs/helm-repsoitory.md
@@ -9,7 +9,7 @@ Helm Repository is split into two branches:
 ## Helm Repository URL
 
 Both branches will be hosted via GitHub Pages within this
-repository ([eclipse-tractus-x/tractus-x-release](https://github.com/eclipse-tractus-x/tractus-x-release)) and will be
+repository ([eclipse-tractus-x/tractus-x-release](https://github.com/eclipse-tractusx/tractus-x-release)) and will be
 accessible under URL
 
 - https://tractus-x-release.github.io/charts/dev for Dev branch

--- a/docs/helm-repsoitory.md
+++ b/docs/helm-repsoitory.md
@@ -31,3 +31,19 @@ release. In the future, Helm charts associated with Tractus-X versions which hav
 removed from the stable branch.
 
 The Helm repository for stable branch will be updated when a new Tractus-X release or a patch update is released.
+
+## Usage
+
+### Dev Branch
+
+```shell
+$ helm repo add tractusx-dev https://eclipse-tractusx.github.io/tractus-x-release/charts/dev
+$ helm install my-release tractusx-dev/sub-product-name
+```
+
+### Stable Branch
+
+```shell
+$ helm repo add tractusx https://eclipse-tractusx.github.io/tractus-x-release/charts/stable
+$ helm install my-release tractusx/sub-product-name
+```


### PR DESCRIPTION
Adding a first basic documentation for a central Tractus-X Helm repository and its usage and linked it in top level `README.md` file. Also a `.gitignore` file have been added.