### PR TITLE
chore: rel 2.1.0 (aka wave-b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,45 @@ Note: Versions listed in this log refer to the app version of the mentioned comp
 may have version numbers which differ from the app version.
 
 ## Unreleased
-- [Portal (Registration)](https://github.com/eclipse-tractusx/portal-frontend-registration), v0.5.4
-- [Managed Identity Wallet](https://github.com/eclipse-tractusx/managed-identity-wallets) (MIW), v0.5.2
 
-## [2.0.0] 2022-12-14
+- n/a
+
+## [2.1.0] - 21-Dec-2022
 
 ### Added
+
+- [Portal](https://github.com/eclipse-tractusx/portal-frontend), v0.6.0
+- [Managed Identity Wallet (MIW)](https://github.com/eclipse-tractusx/managed-identity-wallets), v2.1.0
+- [Simple Data Exchanger (SDE)](https://github.com/eclipse-tractusx/dft-frontend), v1.7.0
+- [Autosetup Service](https://github.com/eclipse-tractusx/autosetup-backend), v1.0.1
+- [DAPS Registration Service](https://github.com/eclipse-tractusx/daps-registration-service/), v1.0.5
+- [Self Description (SD) Factory](https://github.com/eclipse-tractusx/sd-factory), v1.0.6
+- [Semantic Hub](https://github.com/eclipse-tractusx/sldt-semantic-hub), v0.1.0M1
+- [Item Relationship Service (IRS)](https://github.com/eclipse-tractusx/item-relationship-service), v1.3.0
+
+### Known knowns
+
+- Developed considering [Gaia-X](https://gaia-x.eu/) Trust Framework - 22.04
+- FOSS components developed and pre-tested to TRL6 with artificial test data only
+- Restricted crosscheck of functionality in verification environment:  
+  Smoke-tests did not verify
+  - Approval of company registration
+  - Mutiple user onboarding
+  - Registration of EDC and associated SD validations
+  - IRS
+- No execution of Load-, Performance- or Penetration Tests
+- No assignment of Export Control Classification Numbers (ECCN) to FOSS components
+- GeoBlocking recommended for Operations (GBaaS)
+
+### Runtime
+
+- Tested on [Kubernetes](https://en.wikipedia.org/wiki/Kubernetes) versions: `1.24.3`
+- Tested with [PostgreSQL](https://en.wikipedia.org/wiki/PostgreSQL) versions: `1.11`
+
+## [2.0.0] - 2022-12-14
+
+### Added
+
 - [Eclipse Data Space Connector (EDC)](https://github.com/eclipse-tractusx/tractusx-edc), v0.1.2
 - [Golden Record Business Partner Number (BPN) Service](https://github.com/eclipse-tractusx/bpdm), v2.0.0
 - [Dynamic Attribute Provisioning Service (DAPS)](https://github.com/eclipse-tractusx/daps-helm-chart/), v1.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ may have version numbers which differ from the app version.
 
 - n/a
 
-## [2.1.0] - 21-Dec-2022
+## [2.1.0] - 2022-12-21
 
 ### Added
 


### PR DESCRIPTION
Update `CHANGELOG.md`for release 2.1.0 (aka Release 2 wave-b)