### PR TITLE
chore: add reference to tractus-x changelog in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The overarching project is guided by [https://catena-x.net](https://catena-x.net) and all development work is covered in [https://eclipse-tractusx.github.io](https://eclipse-tractusx.github.io/).
 
-The official changelog, including compatibility matrices for Tractus-X releases, can be found at [https://eclipse-tractusx.github.io/changelog](https://eclipse-tractusx.github.io/changelog).
+The overarching changelog for Tractus-X releases, including compatibility matrices, can be found at [https://eclipse-tractusx.github.io/changelog](https://eclipse-tractusx.github.io/changelog).
 
 All notable changes on the overarching level will be documented in this file. Refer to component repositories for specific content, changelog and documentation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The overarching project is guided by [https://catena-x.net](https://catena-x.net) and all development work is covered in [https://eclipse-tractusx.github.io](https://eclipse-tractusx.github.io/).
 
+The official changelog, including compatibility matrices for Tractus-X releases, can be found at [https://eclipse-tractusx.github.io/changelog](https://eclipse-tractusx.github.io/changelog).
+
 All notable changes on the overarching level will be documented in this file. Refer to component repositories for specific content, changelog and documentation.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Pull request resulted from discussion https://github.com/eclipse-tractusx/sig-infra/discussions/373

I suggest placing the reference to the tractus-x changelog in the changelog.md of each repository. Since it is not a must, there is no need to include it in the TRG. 

The[TRG 1.03](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-3) does not describe on how a changelog explicitly has to look, and only provides an example of one that links to the one in this repo. I suggest to only modify the changelog example. This way, the changelog can be copied with the reference line.
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
