### PR TITLE
feat(workflow): add sanity-check-action

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -1,0 +1,30 @@
+name: Sanity Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Release version (e.g. 24.05)'
+        required: true
+        type: string
+
+jobs:
+  run-sanity-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r tools/sanity-check/requirements.txt
+      - name: Run sanity-check
+        run: |
+          source venv/bin/activate
+          python tools/sanity-check/check.py CHANGELOG.md ${{ github.event.inputs.release }}
+


### PR DESCRIPTION
## Description

This PR introduces a github action which executes the sanity-check on a given branch with a specific release name (As parameter -> see screenshot).

=> The action can only be triggered manual because I need the release version as parameter

**new action**

<img width="1665" height="354" alt="image" src="https://github.com/user-attachments/assets/ebac68f0-0fad-4ec9-9a97-4827100a5f4f" />

**Execution**

<img width="334" height="247" alt="image" src="https://github.com/user-attachments/assets/4716a94c-8e80-4e9d-8aae-3745cee948f9" />


**Benefit/Result**

Why? Because sometimes i just want to do a last check... in this case i dont have to clone/pull the repository and i dont care about python and the execution. The [result](https://github.com/stephanbcbauer/tractus-x-release/actions/runs/17976800356/job/51132197948#step:5:24) is the same.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
