### PR TITLE
chore: pin GitHub Actions workflows to immutable SHA digests

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.3.0
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -27,4 +27,3 @@ jobs:
         run: |
           source venv/bin/activate
           python tools/sanity-check/check.py CHANGELOG.md ${{ github.event.inputs.release }}
-


### PR DESCRIPTION
### Description
This PR pins GitHub Action versions to immutable commit SHAs in the `sanity-check.yml` workflow file. This is part of the organization-wide security hardening effort

### Changes
- Pinned `actions/checkout` to `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
- Pinned `actions/setup-python` to `a26af69be951a213d495a4c3e4e4022e16d87065` (v5.3.0)

### Verification
Changes were verified by auditing the repository's workflow configuration. Pinned SHAs correspond to the current state of the respective action branches.